### PR TITLE
Hexo 6.0.0 support

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "yaspeller-ci": "^1.0.2"
   },
   "peerDependencies": {
-    "hexo": "^5.0.0"
+    "hexo": ">=5.0.0"
   },
   "engines": {
     "node": ">=12"


### PR DESCRIPTION
*Forgive me for using translation.*

[News: Hexo 6.0.0 Released](https://hexo.io/news/2021/12/26/hexo-6-0-0-released/)
Error installing under Hexo 6.0.0.
```
C:\Users\Android\Documents\GitHub\hexo-site>npm i hexo-offline
npm ERR! code ERESOLVE
npm ERR! ERESOLVE unable to resolve dependency tree
npm ERR!
npm ERR! While resolving: hexo-site@0.0.0
npm ERR! Found: hexo@6.0.0
npm ERR! node_modules/hexo
npm ERR!   hexo@"^6.0.0" from the root project
npm ERR!
npm ERR! Could not resolve dependency:
npm ERR! peer hexo@"^5.0.0" from hexo-offline@2.0.0
npm ERR! node_modules/hexo-offline
npm ERR!   hexo-offline@"^2.0.0" from the root project
npm ERR!
npm ERR! Fix the upstream dependency conflict, or retry
npm ERR! this command with --force, or --legacy-peer-deps
npm ERR! to accept an incorrect (and potentially broken) dependency resolution.
npm ERR!
npm ERR! See C:\Users\Android\AppData\Local\npm-cache\eresolve-report.txt for a full report.

npm ERR! A complete log of this run can be found in:
npm ERR!     C:\Users\Android\AppData\Local\npm-cache\_logs\2022-01-06T07_38_19_125Z-debug-0.log
```
I noticed that many plug-ins do not even declare the `peerDependencies` field.
Maybe we can relax some version requirements?